### PR TITLE
Add docs and test coverage for dlopen feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,15 @@ rust:
   - 1.46.0
 
 before_install:
-  - sudo apt-get -y install libfontconfig1-dev
+  - sudo apt-get -y install libfontconfig1-dev jq
 
 script:
   - cargo test
-  # Rust 1.46.0 cargo doesn't accept carget tests --features
+  - ./ci/ldd-grep
+
+  # Rust 1.46.0 cargo doesn't accept carget test --features
   - cargo test --features dlopen --manifest-path fontconfig/Cargo.toml
+  - ./ci/ldd-grep -v -- --features dlopen --manifest-path fontconfig/Cargo.toml
+
   - RUST_FONTCONFIG_DLOPEN=on cargo test
+  - RUST_FONTCONFIG_DLOPEN=on ./ci/ldd-grep -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,18 +10,14 @@ addons:
     update: true
 
 rust:
-  - nightly
-  - beta
   - stable
   - 1.46.0
-
-jobs:
-  allow_failures:
-    - rust: nightly
 
 before_install:
   - sudo apt-get -y install libfontconfig1-dev
 
 script:
   - cargo test
+  # Rust 1.46.0 cargo doesn't accept carget tests --features
+  - cargo test --features dlopen --manifest-path fontconfig/Cargo.toml
   - RUST_FONTCONFIG_DLOPEN=on cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,26 @@ before_install:
 
 script:
   - cargo test
-  - ./ci/ldd-grep
+  - |
+    if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then
+      ./ci/ldd-grep
+    else
+      true
+    fi
 
   # Rust 1.46.0 cargo doesn't accept carget test --features
   - cargo test --features dlopen --manifest-path fontconfig/Cargo.toml
-  - ./ci/ldd-grep -v -- --features dlopen --manifest-path fontconfig/Cargo.toml
+  - |
+    if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then
+      ./ci/ldd-grep -v -- --features dlopen
+    else
+      true
+    fi
 
   - RUST_FONTCONFIG_DLOPEN=on cargo test
-  - RUST_FONTCONFIG_DLOPEN=on ./ci/ldd-grep -v
+  - |
+    if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then
+      RUST_FONTCONFIG_DLOPEN=on ./ci/ldd-grep -v
+    else
+      true
+    fi

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ fn main() {
 
 You could then, for example, use `font.path` to create a `GlyphCache` from [`opengl_graphics`][gl] and pass it to [`conrod`][conrod].
 
+### Cargo Features
+
+| Feature       | Description                       | Default Enabled | Extra Dependencies    |
+|---------------|-----------------------------------|:---------------:|-----------------------|
+| `dlopen`      | [dlopen] libfontconfig at runtime |        ❌       |                       |
+
+The `dlopen` feature enables building this crate without dynamically linking to the Fontconfig C library at link time. Instead, Fontconfig will be dynamically loaded at runtime with the [dlopen] function. This can be useful in cross-compiling situations as you don't need to have a version of Fontcofig available for the target platform available at compile time.
+
 Other Fontconfig Crates
 -----------------------
 
@@ -80,3 +88,5 @@ name](https://github.com/abonander/fontconfig-rs/issues/9).
 [yeslogic-fontconfig]: https://crates.io/crates/yeslogic-fontconfig
 [yeslogic-fontconfig-sys]: https://crates.io/crates/yeslogic-fontconfig-sys
 [abonander]: https://github.com/abonander
+[dlopen]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/dlopen.html
+[dlib]: https://crates.io/crates/dlib

--- a/ci/ldd-grep
+++ b/ci/ldd-grep
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -eu
+
+INVERT_MATCH=""
+while getopts "v" opt; do
+    case "$opt" in
+        v) INVERT_MATCH=1;;
+        *) ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+
+EXE=$(cargo test --no-run --message-format=json "$@" | \
+  jq --raw-output 'select(.reason == "compiler-artifact" and .target.name == "fontconfig" and .target.test and .executable != null) | .executable')
+
+
+FOUND=""
+if ldd "$EXE" | grep --quiet libfontconfig ; then
+  FOUND=1
+fi
+
+if [ -z $INVERT_MATCH ]; then
+  if [ -z $FOUND ]; then
+    echo "fail - libfontconfig not found when expected"
+    exit 1
+  else
+    echo "ok - libfontconfig found"
+  fi
+else
+  if [ -z $FOUND ]; then
+    echo "ok - libfontconfig not found"
+  else
+    echo "fail - libfontconfig found when not expected"
+    exit 1
+  fi
+fi

--- a/fontconfig-sys/Cargo.toml
+++ b/fontconfig-sys/Cargo.toml
@@ -20,18 +20,20 @@ repository = "https://github.com/yeslogic/fontconfig-rs"
 
 links = "fontconfig"
 
-[badges]
-travis-ci = { repository = "yeslogic/fontconfig-rs" }
-
 [lib]
 name = "fontconfig_sys"
 
 [dependencies]
 const-cstr = "0.3"
 dlib = "0.5.0"
-# This cannot be optional because build.rs can't conditionally enable it
-# when the RUST_FONTCONFIG_DLOPEN environment variable is set.
-lazy_static = "1.4.0"
+# This can't be optional because build.rs can't conditionally enable an
+# optional dependency:
+#
+# > Note that this does not affect Cargo's dependency resolution. This cannot
+# > be used to enable an optional dependency, or enable other Cargo features.
+#
+# - https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-cfg
+once_cell = "1.9.0"
 
 [features]
 dlopen = []

--- a/fontconfig-sys/build.rs
+++ b/fontconfig-sys/build.rs
@@ -1,5 +1,6 @@
 fn main() {
-    let dlopen = std::env::var("RUST_FONTCONFIG_DLOPEN").is_ok();
+    println!("cargo:rerun-if-env-changed=RUST_FONTCONFIG_DLOPEN");
+    let dlopen = std::env::var_os("RUST_FONTCONFIG_DLOPEN").is_some();
     if dlopen {
         println!("cargo:rustc-cfg=feature=\"dlopen\"");
     }

--- a/fontconfig-sys/src/lib.rs
+++ b/fontconfig-sys/src/lib.rs
@@ -14,26 +14,28 @@
 #[macro_use]
 extern crate const_cstr;
 
+use std::os::raw::{c_char, c_double, c_int, c_uchar, c_uint, c_ushort, c_void};
+
 pub use dlib::ffi_dispatch;
 
 #[cfg(feature = "dlopen")]
-static SONAME: &str = if cfg!(windows) {
-    "libfontconfig.dll"
-} else if cfg!(target_vendor = "apple") {
-    "libfontconfig.dylib.1"
-} else {
-    "libfontconfig.so.1"
-};
+pub mod statics {
+    use super::Fc;
+    use once_cell::sync::Lazy;
 
-#[cfg(feature = "dlopen")]
-lazy_static::lazy_static! {
-    pub static ref LIB: &'static Fc = LIB_RESULT.as_ref().unwrap();
+    static SONAME: &str = if cfg!(windows) {
+        "libfontconfig.dll"
+    } else if cfg!(target_vendor = "apple") {
+        "libfontconfig.dylib.1"
+    } else {
+        "libfontconfig.so.1"
+    };
 
-    pub static ref LIB_RESULT: Result<Fc, dlib::DlError> =
-        unsafe { Fc::open(SONAME) };
+    pub static LIB_RESULT: Lazy<Result<Fc, dlib::DlError>> =
+        Lazy::new(|| unsafe { Fc::open(SONAME) });
+
+    pub static LIB: Lazy<&'static Fc> = Lazy::new(|| LIB_RESULT.as_ref().unwrap());
 }
-
-use std::os::raw::{c_char, c_double, c_int, c_uchar, c_uint, c_ushort, c_void};
 
 pub type FcChar8 = c_uchar;
 pub type FcChar16 = c_ushort;

--- a/fontconfig/Cargo.toml
+++ b/fontconfig/Cargo.toml
@@ -19,9 +19,6 @@ homepage = "https://github.com/yeslogic/fontconfig-rs"
 documentation = "https://docs.rs/crate/fontconfig"
 repository = "https://github.com/yeslogic/fontconfig-rs"
 
-[badges]
-travis-ci = { repository = "yeslogic/fontconfig-rs" }
-
 [dependencies.yeslogic-fontconfig-sys]
 path = "../fontconfig-sys"
 

--- a/fontconfig/build.rs
+++ b/fontconfig/build.rs
@@ -1,5 +1,6 @@
 fn main() {
-    let dlopen = std::env::var("RUST_FONTCONFIG_DLOPEN").is_ok();
+    println!("cargo:rerun-if-env-changed=RUST_FONTCONFIG_DLOPEN");
+    let dlopen = std::env::var_os("RUST_FONTCONFIG_DLOPEN").is_some();
     if dlopen {
         println!("cargo:rustc-cfg=feature=\"dlopen\"");
     }

--- a/fontconfig/src/lib.rs
+++ b/fontconfig/src/lib.rs
@@ -8,6 +8,7 @@
 //! See the [Fontconfig developer reference][1] for more information.
 //!
 //! [1]: http://www.freedesktop.org/software/fontconfig/fontconfig-devel/t1.html
+//! [homepage]: https://www.freedesktop.org/wiki/Software/fontconfig/
 //!
 //! Dependencies
 //! ============
@@ -18,12 +19,10 @@
 //! * Void Linux: `fontconfig-devel`
 //!
 //! Usage
-//! =====
-//!
-//! `main.rs`:
+//! -----
 //!
 //! ```
-//! use fontconfig::{Font, Fontconfig};
+//! use fontconfig::Fontconfig;
 //!
 //! fn main() {
 //!     let fc = Fontconfig::new().unwrap();
@@ -33,6 +32,18 @@
 //!     println!("Name: {}\nPath: {}", font.name, font.path.display());
 //! }
 //! ```
+//!
+//! ### Cargo Features
+//!
+//! | Feature       | Description                       | Default Enabled | Extra Dependencies    |
+//! |---------------|-----------------------------------|:---------------:|-----------------------|
+//! | `dlopen`      | [dlopen] libfontconfig at runtime |        ❌       |                       |
+//!
+//! The `dlopen` feature enables building this crate without dynamically linking to the Fontconfig C
+//! library at link time. Instead, Fontconfig will be dynamically loaded at runtime with the
+//! [dlopen] function. This can be useful in cross-compiling situations as you don't need to have a
+//! version of Fontcofig available for the target platform available at compile time.
+
 
 use fontconfig_sys as sys;
 use fontconfig_sys::ffi_dispatch;

--- a/fontconfig/src/lib.rs
+++ b/fontconfig/src/lib.rs
@@ -38,7 +38,7 @@ use fontconfig_sys as sys;
 use fontconfig_sys::ffi_dispatch;
 
 #[cfg(feature = "dlopen")]
-use sys::{LIB, LIB_RESULT};
+use sys::statics::{LIB, LIB_RESULT};
 #[cfg(not(feature = "dlopen"))]
 use sys::*;
 


### PR DESCRIPTION
This PR documents the `dlopen` cargo feature and adds some CI test coverage that the feature is working as intended. In creating the test I noticed that the crates were not rebuilt when the `RUST_FONTCONFIG_DLOPEN` change. That has been fixed too.

It also uses once_cell instead of lazy_static as it has been [proposed for inclusion in the standard library](https://github.com/rust-lang/rust/issues/74465).