### PR TITLE
Add index field for Font

### DIFF
--- a/fontconfig/src/lib.rs
+++ b/fontconfig/src/lib.rs
@@ -134,6 +134,8 @@ pub struct Font {
     pub name: String,
     /// The location of this font on the filesystem.
     pub path: PathBuf,
+    /// The index of the font within the file.
+    pub index: Option<i32>,
 }
 
 impl Font {
@@ -153,6 +155,7 @@ impl Font {
             font_match.filename().map(|filename| Font {
                 name: name.to_owned(),
                 path: PathBuf::from(filename),
+                index: font_match.face_index(),
             })
         })
     }


### PR DESCRIPTION
Otherwise `Font.path` is kinda useless in cases when file contain multiple fonts.