### PR TITLE
Remove license ambiguity from fontconfig-sys

### DIFF
--- a/fontconfig-sys/src/lib.rs
+++ b/fontconfig-sys/src/lib.rs
@@ -1,11 +1,8 @@
 // Copyright 2013 The Servo Project Developers. See the LICENSE
 // file at the top-level directory of this distribution.
 //
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
+// Licensed under the the MIT license. This file may not be
+// copied, modified, or distributed except according to those terms.
 
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]


### PR DESCRIPTION
The code imported from servo was licensed under the MIT licence and is attributed in the LICENSE file.

Fixes #29 