### PR TITLE
Call default_substitute after config_substitute

### DIFF
--- a/fontconfig/src/lib.rs
+++ b/fontconfig/src/lib.rs
@@ -295,8 +295,8 @@ impl<'fc> Pattern<'fc> {
 
     /// Get the best available match for this pattern, returned as a new pattern.
     pub fn font_match(&mut self) -> Pattern {
-        self.default_substitute();
         self.config_substitute();
+        self.default_substitute();
 
         unsafe {
             let mut res = sys::FcResultNoMatch;


### PR DESCRIPTION
The Fontconfig documentation doesn't specify the order, instead just saying:

> This function should be called only after FcConfigSubstitute and FcDefaultSubstitute have been called for pattern; otherwise the results will not be correct.

However, [a code search on GitHub](https://github.com/search?utf8=%E2%9C%93&q=FcDefaultSubstitute&type=code) shows that `FcDefaultSubstitute` is typically called after `FcConfigSubstitute`, as do [the tools in Fontconfig itself](https://gitlab.freedesktop.org/fontconfig/fontconfig/-/blob/c0118a3bea1d3857d5be13b4ae575c638decb9a3/fc-match/fc-match.c#L185-186).

Fixes #46 