### PR TITLE
`std::os::raw::*` -> `core::ffi::*`, as recommended

### DIFF
--- a/fontconfig-sys/src/lib.rs
+++ b/fontconfig-sys/src/lib.rs
@@ -8,7 +8,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-use std::os::raw::{c_char, c_double, c_int, c_uchar, c_uint, c_ushort, c_void};
+use core::ffi::{c_char, c_double, c_int, c_uchar, c_uint, c_ushort, c_void};
 
 pub use dlib::ffi_dispatch;
 

--- a/fontconfig/src/lib.rs
+++ b/fontconfig/src/lib.rs
@@ -54,10 +54,10 @@ use sys::statics::{LIB, LIB_RESULT};
 #[cfg(not(feature = "dlopen"))]
 use sys::*;
 
+use core::ffi::c_char;
 use std::ffi::{c_int, CStr, CString};
 use std::marker::PhantomData;
 use std::mem;
-use std::os::raw::c_char;
 use std::path::PathBuf;
 use std::ptr;
 use std::str::FromStr;


### PR DESCRIPTION
As discussed, this is a small PR to use the recommended `core::ffi::*` imports instead of `std::os::raw::*`.

---
I said I'd separate the useful stuff, but it turns out that without the full `no_std` implementation, that's just 2 lines :sweat_smile: