### PR TITLE
add CharSet and functions to use them

### DIFF
--- a/fontconfig/src/lib.rs
+++ b/fontconfig/src/lib.rs
@@ -54,8 +54,7 @@ use sys::statics::{LIB, LIB_RESULT};
 #[cfg(not(feature = "dlopen"))]
 use sys::*;
 
-use core::ffi::c_char;
-use std::ffi::{c_int, CStr, CString};
+use std::ffi::{c_char, c_int, CStr, CString};
 use std::marker::PhantomData;
 use std::mem;
 use std::path::PathBuf;
@@ -63,7 +62,7 @@ use std::ptr;
 use std::str::FromStr;
 
 pub use sys::constants::*;
-use sys::{FcBool, FcPattern, FcCharSet};
+use sys::{FcBool, FcCharSet, FcPattern};
 
 #[allow(non_upper_case_globals)]
 const FcTrue: FcBool = 1;
@@ -230,7 +229,13 @@ impl<'fc> Pattern<'fc> {
     /// Add a charset to this pattern
     pub fn add_charset(&mut self, val: CharSet) {
         unsafe {
-            ffi_dispatch!(LIB, FcPatternAddCharSet, self.pat, FC_CHARSET.as_ptr(), val.char_set);
+            ffi_dispatch!(
+                LIB,
+                FcPatternAddCharSet,
+                self.pat,
+                FC_CHARSET.as_ptr(),
+                val.char_set
+            );
         }
     }
 
@@ -639,31 +644,31 @@ impl FromStr for FontFormat {
     }
 }
 
-/// A safe wrapper around fontconfig's `FcCharSet`
+/// Wrapper around `FcCharSet`.
 #[repr(C)]
-pub struct CharSet<'fc> {
+pub struct CharSet {
     char_set: *mut FcCharSet,
-    fc: &'fc Fontconfig,
 }
 
-impl<'fc> CharSet<'fc> {
-    /// Creates an empty char set by calling `FcCharSetCreate()`
-    pub fn new(fc: &'fc Fontconfig) -> Self {
-        let char_set = unsafe {ffi_dispatch!(LIB, FcCharSetCreate,)};
+impl<'fc> CharSet {
+    /// Create a new, empty `CharSet`.
+    pub fn new(_: &'fc Fontconfig) -> Self {
+        let char_set = unsafe { ffi_dispatch!(LIB, FcCharSetCreate,) };
         assert!(!char_set.is_null());
 
-        Self { char_set, fc }
+        Self { char_set }
     }
 
-    /// Add specified char to the charset
-    pub fn add_char(&mut self, c: char) ->  bool {
-        unsafe {
-            ffi_dispatch!(LIB, FcCharSetAddChar, self.char_set, c as u32) != 0
-        }
+    /// Add a char to the `CharSet`.
+    ///
+    /// Returns `false` on failure, either as a result of a constant set or from
+    /// running out of memory.
+    pub fn add_char(&mut self, c: char) -> bool {
+        unsafe { ffi_dispatch!(LIB, FcCharSetAddChar, self.char_set, c as u32) != 0 }
     }
 }
 
-impl<'fc> Drop for CharSet<'fc> {
+impl Drop for CharSet {
     fn drop(&mut self) {
         unsafe {
             ffi_dispatch!(LIB, FcCharSetDestroy, self.char_set);
@@ -781,8 +786,8 @@ mod tests {
         pat.add_string(FC_STYLE, &family);
         pat.add_charset(char_set);
         let font_set = list_fonts(&pat, None);
-        
+
         // Font set should be empty
-        assert!(font_set.iter().count() == 0);
+        assert_eq!(font_set.iter().count(), 0);
     }
 }

--- a/fontconfig/src/lib.rs
+++ b/fontconfig/src/lib.rs
@@ -641,22 +641,32 @@ impl FromStr for FontFormat {
 
 /// A safe wrapper around fontconfig's `FcCharSet`
 #[repr(C)]
-pub struct CharSet {
+pub struct CharSet<'fc> {
     char_set: *mut FcCharSet,
+    fc: &'fc Fontconfig,
 }
 
-impl CharSet {
-    /// Creates an empt char set by calling `FcCharSetCreate()`
-    pub fn create() -> Self {
-        unsafe {
-            Self { char_set: ffi_dispatch!(LIB, FcCharSetCreate,) }
-        }
+impl<'fc> CharSet<'fc> {
+    /// Creates an empty char set by calling `FcCharSetCreate()`
+    pub fn new(fc: &'fc Fontconfig) -> Self {
+        let char_set = unsafe {ffi_dispatch!(LIB, FcCharSetCreate,)};
+        assert!(!char_set.is_null());
+
+        Self { char_set, fc }
     }
 
     /// Add specified char to the charset
-    pub fn add_char(&mut self, c: char) {
+    pub fn add_char(&mut self, c: char) ->  bool {
         unsafe {
-            ffi_dispatch!(LIB, FcCharSetAddChar, self.char_set, c as u32);
+            ffi_dispatch!(LIB, FcCharSetAddChar, self.char_set, c as u32) != 0
+        }
+    }
+}
+
+impl<'fc> Drop for CharSet<'fc> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi_dispatch!(LIB, FcCharSetDestroy, self.char_set);
         }
     }
 }
@@ -745,5 +755,34 @@ mod tests {
 
         // Ensure that the set can be iterated again
         assert!(font_set.iter().count() > 0);
+    }
+
+    #[test]
+    fn finds_font_containing_charset() {
+        let fc = Fontconfig::new().unwrap();
+        let mut pat = Pattern::new(&fc);
+        let mut char_set = CharSet::new(&fc);
+        char_set.add_char('a');
+        pat.add_charset(char_set);
+        let font_set = list_fonts(&pat, None);
+
+        // Should find at least one font
+        assert!(font_set.iter().count() > 0);
+    }
+
+    #[test]
+    fn does_not_find_missing_charset() {
+        let fc = Fontconfig::new().unwrap();
+        let mut pat = Pattern::new(&fc);
+        let mut char_set = CharSet::new(&fc);
+        // DejaVu Sans does not support CJK so try finding it for the following U+5317
+        char_set.add_char('北');
+        let family = CString::new("dejavu sans").unwrap();
+        pat.add_string(FC_STYLE, &family);
+        pat.add_charset(char_set);
+        let font_set = list_fonts(&pat, None);
+        
+        // Font set should be empty
+        assert!(font_set.iter().count() == 0);
     }
 }

--- a/fontconfig/src/lib.rs
+++ b/fontconfig/src/lib.rs
@@ -63,7 +63,7 @@ use std::ptr;
 use std::str::FromStr;
 
 pub use sys::constants::*;
-use sys::{FcBool, FcPattern};
+use sys::{FcBool, FcPattern, FcCharSet};
 
 #[allow(non_upper_case_globals)]
 const FcTrue: FcBool = 1;
@@ -224,6 +224,13 @@ impl<'fc> Pattern<'fc> {
     pub fn add_integer(&mut self, name: &CStr, val: c_int) {
         unsafe {
             ffi_dispatch!(LIB, FcPatternAddInteger, self.pat, name.as_ptr(), val);
+        }
+    }
+
+    /// Add a charset to this pattern
+    pub fn add_charset(&mut self, val: CharSet) {
+        unsafe {
+            ffi_dispatch!(LIB, FcPatternAddCharSet, self.pat, FC_CHARSET.as_ptr(), val.char_set);
         }
     }
 
@@ -628,6 +635,28 @@ impl FromStr for FontFormat {
             "PFR" => Ok(FontFormat::PFR),
             "Windows FNT" => Ok(FontFormat::WindowsFNT),
             _ => Err(UnknownFontFormat(s.to_string())),
+        }
+    }
+}
+
+/// A safe wrapper around fontconfig's `FcCharSet`
+#[repr(C)]
+pub struct CharSet {
+    char_set: *mut FcCharSet,
+}
+
+impl CharSet {
+    /// Creates an empt char set by calling `FcCharSetCreate()`
+    pub fn create() -> Self {
+        unsafe {
+            Self { char_set: ffi_dispatch!(LIB, FcCharSetCreate,) }
+        }
+    }
+
+    /// Add specified char to the charset
+    pub fn add_char(&mut self, c: char) {
+        unsafe {
+            ffi_dispatch!(LIB, FcCharSetAddChar, self.char_set, c as u32);
         }
     }
 }


### PR DESCRIPTION
fontconfig supports filtering fonts by a set of required characters that it must support. This pull requests adds the ability to define a charset and add characters to it, as well as then adding that CharSet to a pattern for searching